### PR TITLE
changed wrong topscope ssl variable and conditional

### DIFF
--- a/sections/modules/03_parameterized_classes.md
+++ b/sections/modules/03_parameterized_classes.md
@@ -135,10 +135,10 @@ setup.
       Boolean                  $ssl    = false,
     ) {
       ...
-      if $::osfamily {
+      case $::osfamily {
         'RedHat': {
           package {'mod_ssl':
-            ensure => $::ssl ? {
+            ensure => $ssl ? {
               true    => installed,
               default => absent,
             }


### PR DESCRIPTION
Just a wrong $::ssl topscope variable in the the class

And the IF Conditional is wrong when checking the $::osfamily from topscope.
